### PR TITLE
feat: build negation aware cohort rag app

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -1,108 +1,149 @@
-#main_app.py
+"""Streamlit entry point for the Cohort Analysis System."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import pandas as pd
 import streamlit as st
-from summarizer import summarizer 
-from chatbot import chatbot
+
+from rag_engine import NegationAwareRAG
+from ui_helpers import build_ready_made_queries, human_readable_size
+from user_vector_store import UserVectorStore
 
 
+st.set_page_config(page_title="LLM Cohort Copilot", layout="wide")
 
 
-
-st.set_page_config(page_title="Amrita HIS Patient Cohort Dashboard", layout="wide")
-st.sidebar.title("Cohort Insights Menu")
-page = st.sidebar.selectbox("Please select whether you want to explore or summarize patient cohorts:", ["Amrita HIS Patient Cohort Explorer","Amrita HIS Patient Cohort Summarizer"])
-
-if page == "Amrita HIS Patient Cohort Summarizer":
-    summarizer()
-
-elif page == "Amrita HIS Patient Cohort Explorer":
-    # Inject CSS for custom dialog styling and button text-like appearance
-    st.markdown(
-        """
-        <style>
-        /* Customize dialog size */
-        div[data-testid="stDialog"] div[role="dialog"]:has(.big-dialog) {
-            width: 80vw;
-            height: 80vh;
-            overflow: auto;
-        }
-
-        /* Base button style */
-        button[kind="primary"] {
-            width: 100%;
-            background-color: #ffffff;       /* clean white */
-            border: 2px solid #1e293b;       /* dark navy border */
-            border-radius: 0;            /* pill shape */
-            color: #1e293b;                   /* dark navy text */
-            font-family: "Basier circle", -apple-system, system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-            font-weight: 600 !important;
-            font-size: 0.6rem !important;
-            padding: 2px !important;
-            box-shadow: 0 1px 4px rgba(30, 41, 59, 0.25);
-            cursor: pointer;
-            transition: background-color 0.25s ease, color 0.25s ease, box-shadow 0.25s ease;
-            user-select: none;
-            text-align: center;
-            outline: none;
-        }
-
-        /* Hover effect */
-        button[kind="primary"]:hover {
-            background-color: #1e293b;       /* dark navy background */
-            color: #ffffff;                  /* white text */
-            box-shadow: 0 4px 12px rgba(30, 41, 59, 0.4);
-        }
-
-        /* Focus effect */
-        button[kind="primary"]:focus {
-            outline-offset: 2px;
-            box-shadow: none;
-        }
-
-        /* Active / pressed effect */
-        button[kind="primary"]:active {
-            background-color: #15213a;
-            box-shadow: 0 2px 6px rgba(21, 33, 58, 0.6);
-        }
+def _init_state() -> None:
+    if "store" not in st.session_state:
+        st.session_state.store = UserVectorStore()
+    if "rag" not in st.session_state:
+        st.session_state.rag = NegationAwareRAG(st.session_state.store)
+    if "messages" not in st.session_state:
+        st.session_state.messages: List[Dict[str, Any]] = []
+    if "pending_query" not in st.session_state:
+        st.session_state.pending_query = None
 
 
+def _render_sidebar() -> str:
+    st.sidebar.title("Cohort Controls")
+    user_id = st.sidebar.text_input("User / Workspace ID", help="All vector stores are isolated per user.")
 
-        
-        /* Download button style */
-        button[kind="secondary"] {
-            padding: 0px 10px !important;
-            font-size: 1rem !important;
-            border: solid 1px #15213a !important;
-            border-radius: 0 !important;
-        }
-        /* Hover */
-        button[kind="secondary"]:hover {
-            background-color: #15213a !important;
-            color: #ffffff !important;
-            box-shadow: 0 4px 12px rgba(30, 41, 59, 0.4);
-        }
+    if not user_id:
+        st.sidebar.info("Enter your workspace identifier to continue.")
+        return ""
 
-        /* Focus */
-        button[kind="secondary"]:focus {
-            outline-offset: 2px;
-            box-shadow: none;
-            color: black !important;
-        }
+    report = st.session_state.store.get_usage_report(user_id)
+    st.sidebar.metric(
+        "Storage usage",
+        human_readable_size(report["used_bytes"]),
+        help=f"Quota: {human_readable_size(report['quota_bytes'])} ({report['used_percent']}% used)",
+    )
+
+    uploaded_file = st.sidebar.file_uploader(
+        "Upload cohort CSV", type=["csv"], help="Rows are embedded into a private vector index for this user only."
+    )
+    if uploaded_file is not None:
+        try:
+            df = pd.read_csv(uploaded_file)
+            info = st.session_state.store.ingest_dataframe(user_id, df)
+            st.sidebar.success(
+                f"Ingested {info['rows']} rows into your personal vector database. The index persists on disk."
+            )
+        except Exception as exc:  # noqa: BLE001
+            st.sidebar.error(str(exc))
+
+    summary = st.session_state.store.load_dataset_summary(user_id)
+    if summary:
+        st.sidebar.subheader("Dataset snapshot")
+        st.sidebar.write(f"Rows embedded: **{summary['row_count']}**")
+        st.sidebar.caption(f"Columns: {', '.join(summary['columns'])}")
+
+    return user_id
 
 
-        /* Responsive font size for larger screens */
-        @media (min-width: 768px) {
-            button[kind="primary"] {
-                font-size: 1.25rem;
-                padding: 1rem 2.5rem;
-            }
-        }
+def _render_ready_queries(columns: List[str]) -> None:
+    st.subheader("Jump start your analysis")
+    suggestions = build_ready_made_queries(columns)
+    cols = st.columns(len(suggestions)) if suggestions else []
+    for idx, query in enumerate(suggestions):
+        button = cols[idx].button(query, use_container_width=True)
+        if button:
+            st.session_state.pending_query = query
 
 
+def _display_messages() -> None:
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+            if message["role"] == "assistant":
+                if message.get("follow_ups"):
+                    st.markdown("**Suggested questions**")
+                    follow_cols = st.columns(len(message["follow_ups"]))
+                    for idx, text in enumerate(message["follow_ups"]):
+                        if follow_cols[idx].button(text, key=f"follow_{len(st.session_state.messages)}_{idx}"):
+                            st.session_state.pending_query = text
+                if message.get("sources"):
+                    with st.expander("Sources from cohort dataset", expanded=False):
+                        st.dataframe(pd.DataFrame(message["sources"]))
 
-        </style>
-        """,
-            unsafe_allow_html=True,
-        )
 
-    chatbot()
-    
+def _ingest_sources(documents: List[Any]) -> List[Dict[str, Any]]:
+    sources = []
+    for doc in documents:
+        row_meta = {"row_index": doc.metadata.get("row_index"), "polarity": doc.metadata.get("polarity")}
+        row_json = doc.metadata.get("row_json")
+        if row_json:
+            try:
+                row_data = json.loads(row_json)
+                row_meta.update(row_data)
+            except json.JSONDecodeError:
+                row_meta["raw_row"] = row_json
+        sources.append(row_meta)
+    return sources
+
+
+def _handle_user_prompt(user_id: str, prompt: str) -> None:
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    response = st.session_state.rag.answer_question(user_id, prompt)
+    sources = _ingest_sources(response["documents"])
+    assistant_message = {
+        "role": "assistant",
+        "content": response["answer"],
+        "sources": sources,
+        "follow_ups": response.get("follow_ups", []),
+    }
+    st.session_state.messages.append(assistant_message)
+
+
+def main() -> None:
+    _init_state()
+    st.title("Cohort Analysis Copilot")
+    st.caption("An Ollama powered, negation aware RAG workspace with personalised vector stores.")
+
+    user_id = _render_sidebar()
+    if not user_id:
+        return
+
+    summary = st.session_state.store.load_dataset_summary(user_id)
+    _render_ready_queries(summary.get("columns", []) if summary else [])
+
+    _display_messages()
+
+    pending = st.session_state.pending_query
+    if pending:
+        st.session_state.pending_query = None
+        _handle_user_prompt(user_id, pending)
+        st.experimental_rerun()
+
+    prompt = st.chat_input("Ask a cohort intelligence question…")
+    if prompt:
+        _handle_user_prompt(user_id, prompt)
+        st.experimental_rerun()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/negation_utils.py
+++ b/negation_utils.py
@@ -1,0 +1,117 @@
+"""Utility helpers for negation and assertion detection.
+
+The heuristics implemented here do not try to be a full blown
+clinical NLP pipeline.  Instead, they provide lightweight and fast
+rules that work well for the typical structured CSV exports used in
+the cohort explorer.  The module exposes two pieces of functionality:
+
+* ``detect_query_polarity`` – classifies a question into *affirmed*,
+  *negated* or *neutral* buckets so that retrieval can prefer rows
+  expressed with matching polarity.
+* ``label_text_polarity`` – inspects a row converted to natural text
+  and tags it with the same polarity labels.  The result is stored as
+  metadata in the vector store and later used for filtered search.
+
+The rules were inspired by common phrasing found in clinical
+documentation (e.g. “denies chest pain”, “no history of”, “has a
+diagnosis of”).  They are intentionally conservative: if both
+assertive and negated cues are found the function returns ``"mixed"``
+so that the retriever can still surface the chunk as a fall-back.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+NEGATION_KEYWORDS = {
+    "no",
+    "not",
+    "denies",
+    "without",
+    "free of",
+    "ruled out",
+    "never",
+    "negative for",
+    "absent",
+    "lack of",
+    "resolved",
+}
+
+ASSERTION_KEYWORDS = {
+    "has",
+    "with",
+    "history of",
+    "diagnosed",
+    "positive for",
+    "reports",
+    "experiencing",
+    "complains of",
+    "presents with",
+    "found to have",
+}
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace and lowercase the incoming text."""
+
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def _keyword_count(text: str, keywords: Iterable[str]) -> int:
+    """Return how many keyword occurrences are found in ``text``."""
+
+    count = 0
+    for kw in keywords:
+        if kw in text:
+            # Use a lightweight heuristic: count the keyword once per
+            # sentence to avoid over-counting repeated mentions.
+            count += len(re.findall(re.escape(kw), text))
+    return count
+
+
+def label_text_polarity(text: str) -> str:
+    """Label the polarity of a text span.
+
+    The return value is one of ``"affirmed"``, ``"negated"`` or
+    ``"mixed"``.  ``"mixed"`` doubles as a neutral value when no clear
+    cues are present.
+    """
+
+    normalized = _normalize(text)
+    if not normalized:
+        return "mixed"
+
+    negated = _keyword_count(normalized, NEGATION_KEYWORDS)
+    affirmed = _keyword_count(normalized, ASSERTION_KEYWORDS)
+
+    if negated and not affirmed:
+        return "negated"
+    if affirmed and not negated:
+        return "affirmed"
+    return "mixed"
+
+
+def detect_query_polarity(query: str) -> str:
+    """Classify the intent of a user question by polarity.
+
+    The categorisation mirrors :func:`label_text_polarity` so that the
+    retriever can prefer matches with similar polarity.  When neither
+    negation nor assertion cues are detected ``"mixed"`` is returned.
+    """
+
+    normalized = _normalize(query)
+    if not normalized:
+        return "mixed"
+
+    for kw in NEGATION_KEYWORDS:
+        if kw in normalized:
+            return "negated"
+
+    for kw in ASSERTION_KEYWORDS:
+        if kw in normalized:
+            return "affirmed"
+
+    return "mixed"
+

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -1,0 +1,142 @@
+"""Negation aware retrieval augmented generation pipeline."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional, Tuple
+
+from langchain_core.documents import Document
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_ollama.llms import OllamaLLM
+
+from negation_utils import detect_query_polarity
+from user_vector_store import UserVectorStore
+
+
+ANSWER_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            """
+You are a cohort analysis copilot.  Answer clinician questions using the
+provided context.  Respect negations explicitly stated in the
+documents.  If the answer is not present say so.
+
+Structure the response as follows:
+
+1. A concise natural language answer.
+2. A bullet list titled "Key Findings" capturing relevant rows.
+3. A "Sources" section that references each contributing row as
+   `Row <row_index>` followed by a one sentence rationale.
+            """,
+        ),
+        (
+            "human",
+            "Question: {question}\n\nContext:\n{context}",
+        ),
+    ]
+)
+
+
+FOLLOW_UP_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "Suggest three follow-up questions that dig deeper into the dataset."
+            "Focus on nuanced cohort splits, temporal changes, or risk" " signals."
+            "Return them as a JSON list of strings.",
+        ),
+        (
+            "human",
+            "Dataset columns: {columns}\nLatest answer: {answer}",
+        ),
+    ]
+)
+
+
+class NegationAwareRAG:
+    """High level orchestrator of the RAG workflow."""
+
+    def __init__(self, store: UserVectorStore, generator_model: str = "mistral"):
+        self.store = store
+        self.generator = OllamaLLM(model=generator_model)
+
+    # ------------------------------------------------------------------
+    def _load_documents(
+        self, user_id: str, query: str, k: int = 4
+    ) -> Tuple[List[Document], str]:
+        vectordb = self.store.get_vectordb(user_id)
+        if vectordb is None:
+            return [], "mixed"
+
+        polarity = detect_query_polarity(query)
+        documents: List[Document] = []
+
+        def _search(filter_value: Optional[str], remaining: int) -> None:
+            if remaining <= 0:
+                return
+            search_kwargs = {"k": remaining}
+            if filter_value:
+                search_kwargs["filter"] = {"polarity": filter_value}
+            docs = vectordb.similarity_search(query, **search_kwargs)
+            for doc in docs:
+                if doc not in documents:
+                    documents.append(doc)
+
+        if polarity in {"affirmed", "negated"}:
+            _search(polarity, k)
+            if len(documents) < k:
+                _search("mixed", k - len(documents))
+        else:
+            _search(None, k)
+
+        return documents, polarity
+
+    def _prepare_context(self, documents: List[Document]) -> str:
+        context_parts = []
+        for doc in documents:
+            row_idx = doc.metadata.get("row_index", "?")
+            context_parts.append(f"Row {row_idx}: {doc.page_content}")
+        return "\n\n".join(context_parts)
+
+    def answer_question(self, user_id: str, question: str, k: int = 4) -> Dict[str, object]:
+        documents, polarity = self._load_documents(user_id, question, k=k)
+
+        if not documents:
+            return {
+                "answer": "I do not have any data for this cohort yet. Upload a CSV to get started.",
+                "documents": [],
+                "polarity": polarity,
+                "follow_ups": [],
+            }
+
+        context = self._prepare_context(documents)
+        prompt = ANSWER_PROMPT.format(question=question, context=context)
+        raw_answer = self.generator.invoke(prompt)
+
+        cleaned_answer = raw_answer.replace("<think>", "").replace("</think>", "").strip()
+
+        follow_ups = self._suggest_questions(user_id, cleaned_answer)
+
+        return {
+            "answer": cleaned_answer,
+            "documents": documents,
+            "polarity": polarity,
+            "follow_ups": follow_ups,
+        }
+
+    def _suggest_questions(self, user_id: str, latest_answer: str) -> List[str]:
+        summary = self.store.load_dataset_summary(user_id)
+        if not summary:
+            return []
+        prompt = FOLLOW_UP_PROMPT.format(columns=", ".join(summary.get("columns", [])), answer=latest_answer)
+        response = self.generator.invoke(prompt)
+        cleaned = response.replace("<think>", "").replace("</think>", "").strip()
+        try:
+            suggestions = json.loads(cleaned)
+            if isinstance(suggestions, list):
+                return [str(item) for item in suggestions if item]
+        except json.JSONDecodeError:
+            pass
+        return []
+

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -1,0 +1,41 @@
+"""Helper utilities for the Streamlit user interface."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+def build_ready_made_queries(columns: Iterable[str]) -> List[str]:
+    columns = list(columns)
+    suggestions: List[str] = [
+        "Summarize the overall cohort composition.",
+        "Highlight notable risk factors in this cohort.",
+        "List recent admissions or encounters.",
+    ]
+
+    if not columns:
+        return suggestions
+
+    # Surface a couple of column-aware prompts.
+    focus_candidates = columns[:4]
+    for col in focus_candidates:
+        suggestions.append(f"Show patients where {col} is unusual or extreme.")
+    if "diagnosis" in "|".join(columns).lower():
+        suggestions.append("Which diagnoses co-occur most frequently?")
+    if "med" in "|".join(columns).lower():
+        suggestions.append("What medications are commonly prescribed together?")
+    return suggestions[:6]
+
+
+def human_readable_size(num_bytes: int) -> str:
+    """Convert the byte count into a human readable string."""
+
+    step = 1024.0
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(num_bytes)
+    for unit in units:
+        if size < step:
+            return f"{size:.2f} {unit}"
+        size /= step
+    return f"{size:.2f} PB"
+

--- a/user_vector_store.py
+++ b/user_vector_store.py
@@ -1,0 +1,186 @@
+"""User scoped Chroma vector store management.
+
+Each customer of the cohort explorer receives an isolated vector
+database that persists on disk under ``user_vectordbs/<user_id>``.
+Collections are never deleted which satisfies the "no VDB gets
+deleted once made" requirement.  A soft quota keeps storage usage per
+user under control.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+from langchain_chroma import Chroma
+from langchain_core.documents import Document
+from langchain_ollama import OllamaEmbeddings
+
+from negation_utils import label_text_polarity
+
+
+def _sanitize_identifier(raw: str) -> str:
+    """Return a filesystem safe identifier based on ``raw``."""
+
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", raw.strip())
+    return cleaned or "anonymous"
+
+
+def _format_row(row: pd.Series) -> str:
+    """Create a paragraph style string out of a dataframe row."""
+
+    values = []
+    for column, value in row.items():
+        if pd.isna(value):
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        values.append(f"{column}: {text}")
+    return "\n".join(values)
+
+
+def _directory_size(path: Path) -> int:
+    """Calculate the size of a directory recursively in bytes."""
+
+    total = 0
+    if not path.exists():
+        return total
+    for item in path.rglob("*"):
+        if item.is_file():
+            total += item.stat().st_size
+    return total
+
+
+def _estimate_documents_size(documents: Iterable[Document]) -> int:
+    """Rough byte estimate for documents that will be stored."""
+
+    total = 0
+    for doc in documents:
+        total += len(doc.page_content.encode("utf-8"))
+        for value in doc.metadata.values():
+            total += len(str(value).encode("utf-8"))
+    return total
+
+
+@dataclass
+class UserQuota:
+    limit_mb: int = 50
+
+    @property
+    def limit_bytes(self) -> int:
+        return self.limit_mb * 1024 * 1024
+
+
+class UserVectorStore:
+    """Manage per-user Chroma collections backed by Ollama embeddings."""
+
+    def __init__(self, base_dir: str = "user_vectordbs", quota: Optional[UserQuota] = None):
+        self.base_path = Path(base_dir)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.quota = quota or UserQuota()
+        self._embeddings = OllamaEmbeddings(model="nomic-embed-text")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_collection_path(self, user_id: str) -> Path:
+        return self.base_path / _sanitize_identifier(user_id)
+
+    def get_vectordb(self, user_id: str) -> Optional[Chroma]:
+        path = self.get_collection_path(user_id)
+        if not path.exists():
+            return None
+        return Chroma(
+            collection_name=_sanitize_identifier(user_id),
+            persist_directory=str(path),
+            embedding_function=self._embeddings,
+        )
+
+    def ingest_dataframe(self, user_id: str, df: pd.DataFrame) -> Dict[str, str]:
+        """Persist the dataframe as documents for the user.
+
+        Returns basic metadata (row_count and polarity distribution)
+        that can be used by the UI.
+        """
+
+        if df.empty:
+            raise ValueError("The uploaded dataframe is empty.")
+
+        path = self.get_collection_path(user_id)
+        path.mkdir(parents=True, exist_ok=True)
+
+        documents: List[Document] = []
+        polarity_counter = {"affirmed": 0, "negated": 0, "mixed": 0}
+
+        for idx, row in df.iterrows():
+            content = _format_row(row)
+            if not content:
+                continue
+            polarity = label_text_polarity(content)
+            polarity_counter[polarity] += 1
+
+            doc = Document(
+                page_content=content,
+                metadata={
+                    "row_index": int(idx),
+                    "polarity": polarity,
+                    "row_json": json.dumps(row.fillna("").to_dict()),
+                },
+            )
+            documents.append(doc)
+
+        if not documents:
+            raise ValueError("No usable rows were found in the dataset.")
+
+        estimated_addition = _estimate_documents_size(documents)
+        current_size = _directory_size(path)
+        if current_size + estimated_addition > self.quota.limit_bytes:
+            raise ValueError(
+                "Quota exceeded – remove data from the dataset or request a larger allowance."
+            )
+
+        vectordb = Chroma(
+            collection_name=_sanitize_identifier(user_id),
+            persist_directory=str(path),
+            embedding_function=self._embeddings,
+        )
+
+        vectordb.add_documents(documents)
+        vectordb.persist()
+
+        summary_payload = {
+            "row_count": len(documents),
+            "polarity": polarity_counter,
+            "columns": list(df.columns),
+        }
+        summary_path = path / "dataset_summary.json"
+        summary_path.write_text(json.dumps(summary_payload, indent=2))
+
+        return {"rows": str(len(documents)), "path": str(path)}
+
+    def get_usage_report(self, user_id: str) -> Dict[str, str]:
+        path = self.get_collection_path(user_id)
+        current_size = _directory_size(path)
+        percent = (current_size / self.quota.limit_bytes) * 100 if self.quota.limit_bytes else 0
+        return {
+            "used_bytes": current_size,
+            "quota_bytes": self.quota.limit_bytes,
+            "used_percent": round(percent, 2),
+            "exists": path.exists(),
+        }
+
+    def load_dataset_summary(self, user_id: str) -> Optional[Dict[str, object]]:
+        path = self.get_collection_path(user_id) / "dataset_summary.json"
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            return None
+


### PR DESCRIPTION
## Summary
- replace the Streamlit entry point with an Ollama-powered cohort copilot UI styled after modern chat assistants
- add per-user vector store management with persistent, quota-protected Chroma indices
- implement negation-aware retrieval, ready-made prompts, and follow-up suggestion helpers for the RAG experience

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc083677648332a5292bd2baebbbad